### PR TITLE
Updating to user-interface-base latest for display-shield driver fixes

### DIFF
--- a/assets.ts
+++ b/assets.ts
@@ -139,6 +139,12 @@ namespace microcode {
             // sample icons
             if (name == "smiley_buttons") return icondb.sampleSmileyButtons
 
+            //TODO: I think this is actually the Jacdac logo?
+            // user-interface-base/coreAssets.ts has the real microbitLogo
+            // Use "microbitLogo" and at the end of this function it will check user-interface-base and fetch it.
+            if (name == "microbit_logo") return icondb.microbit_logo
+            if (name == "microbitLogoBtn") return icondb.microbit_logo_btn
+
             // pages
 
             if (name == Tid.TID_SENSOR_START_PAGE) return icondb.tile_start_page
@@ -276,6 +282,7 @@ namespace microcode {
             extraSamples(name) // only for web app
             if (extraImage) return extraImage
             if (nullIfMissing) return null
+            if (typeof(name) === "string") return user_interface_base.icons.get(name, nullIfMissing);
             return icondb.MISSING
         }
     }
@@ -304,24 +311,7 @@ namespace microcode {
     .bbbbbff.......bbbbbff.bbbbff...fbbbbbbbfff...bbbbff..........fbbbbbbbfff........fbbbbbbbfff.......fbbbbbbbfff.....fbbbbbbbbbbff...fbbbbbbbbff..
     ..fffff.........fffff...ffff......fffffff......ffff.............fffffff............fffffff...........fffffff.........ffffffffff......ffffffff...
     `
-    export const microbitLogo = bmp`
-        ............................
-        ......5555555555555555......
-        ....55555555555555555555....
-        ...5554444444444444444555...
-        ..5554.................555..
-        ..554...................554.
-        .554....55........55.....554
-        .55....5555......5555....554
-        .55....55554.....55554...554
-        .55.....5544......5544...554
-        ..55.....44........44...5544
-        ..555..................5554.
-        ...555................55544.
-        ....5555555555555555555544..
-        .....45555555555555555444...
-        .......4444444444444444.....
-    `
+
 
     export const editorBackground = bmp`
     8888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888
@@ -1250,6 +1240,9 @@ namespace icondb {
     . . . . . . . . . . . . . . . .
 `
 
+  //TODO: I think this is actually the Jacdac logo?
+  // user-interface-base/coreAssets.ts has the real microbitLogo
+  // Use "microbitLogo" and at the end of this function it will check user-interface-base and fetch it.
     export const microbit_logo = bmp`
     . . . . . . . . . . . . . . . . 
     . . . . . . . . . . . . . . . . 
@@ -1267,24 +1260,6 @@ namespace icondb {
     . . . . . . . . . . . . . . . . 
     . . . . . . . . . . . . . . . . 
     . . . . . . . . . . . . . . . . 
-`
-    export const microbit_logo_btn = bmp`
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . f f f f f f f f . . . . 
-    . . . f 1 1 1 1 1 1 1 1 f . . . 
-    . . f 1 1 1 1 1 1 1 1 1 1 f . . 
-    . . f 1 f f 1 1 1 1 f f 1 f . . 
-    . . f 1 f f 1 1 1 1 f f 1 f . . 
-    . . f 1 1 1 1 1 1 1 1 1 1 f . . 
-    . . . f 1 1 1 1 1 1 1 1 f . . . 
-    . . . . f f f f f f f f . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . .
 `
 
     export const finger_release = bmp`

--- a/editor.ts
+++ b/editor.ts
@@ -227,7 +227,7 @@ namespace microcode {
             this.moveTo(target)
         }
 
-        /* override */ startup(setup: () => void) {
+        /* override */ startup() {
             const makeOnEvent = (id: number, dir: CursorDir) => {
                 control.onEvent(ControllerButtonEvent.Pressed, id, () =>
                     this.scrollAndMove(dir)

--- a/gallery.ts
+++ b/gallery.ts
@@ -14,7 +14,7 @@ namespace microcode {
             super.shutdown()
         }
 
-        /* override */ startup(setup: () => void) {
+        /* override */ startup() {
             super.startup()
 
             let x = -72,

--- a/home.ts
+++ b/home.ts
@@ -12,7 +12,7 @@ namespace microcode {
             super(app)
         }
 
-        /* override */ startup(setup: () => void) {
+        /* override */ startup() {
             super.startup()
 
             this.navigator.setBtns([
@@ -118,9 +118,9 @@ namespace microcode {
                 y + this.yOffset
             )
             Screen.drawTransparentImage(
-                microbitLogo,
+                icondb.microbitLogo,
                 Screen.LEFT_EDGE +
-                    ((Screen.WIDTH - microbitLogo.width) >> 1) +
+                    ((Screen.WIDTH - icondb.microbitLogo.width) >> 1) +
                     dy,
                 y - wordLogo.height + this.yOffset + margin
             )

--- a/pxt.json
+++ b/pxt.json
@@ -3,12 +3,12 @@
     "version": "2.5.47",
     "description": "Physical computing library for micro:bit V2",
     "dependencies": {
-        "core": "file:../core",
-        "radio": "file:../radio",
-        "microphone": "file:../microphone",
-        "datalogger": "file:../datalogger",
-        "settings": "file:../settings",
-        "user-interface-base": "file:../user-interface-base"
+        "core": "*",
+        "radio": "*",
+        "microphone": "*",
+        "datalogger": "*",
+        "settings": "*",
+        "user-interface-base": "github:microbit-apps/user-interface-base#v0.0.29"
     },
     "files": [
         "analytics.ts",

--- a/pxt.json
+++ b/pxt.json
@@ -3,12 +3,12 @@
     "version": "2.5.47",
     "description": "Physical computing library for micro:bit V2",
     "dependencies": {
-        "core": "*",
-        "radio": "*",
-        "microphone": "*",
-        "datalogger": "*",
-        "settings": "*",
-        "user-interface-base": "github:microbit-apps/user-interface-base#v0.0.24"
+        "core": "file:../core",
+        "radio": "file:../radio",
+        "microphone": "file:../microphone",
+        "datalogger": "file:../datalogger",
+        "settings": "file:../settings",
+        "user-interface-base": "file:../user-interface-base"
     },
     "files": [
         "analytics.ts",


### PR DESCRIPTION


- For ST7735 and Jacdac Display driver fixes.
- Removing startupFn arg for Scenes.
- asset.ts pulls from user-interface-base/coreAssets; at the moment as a last resort. In the future we can move more shared assets into there.
- microbitLogo used on the home screen is pulled from user-interface-base/coreAssets.ts